### PR TITLE
Add parenthesis () in front of lru_cache decorator

### DIFF
--- a/drf_messages/storage.py
+++ b/drf_messages/storage.py
@@ -57,7 +57,7 @@ class DBStorage(BaseStorage):
         else:
             return self.get_unread_queryset().filter(message=item.message, level=item.level).exists()
 
-    @lru_cache
+    @lru_cache()
     def __len__(self):
         if self._fallback:
             return len(self._queued_messages)


### PR DESCRIPTION
Calling lru_cache without args is not possible in the latest Python because it acts as a function: https://stackoverflow.com/questions/47218313/use-functools-lru-cache-without-specifying-maxsize-parameter

This is untested so far, because I still can't get drf_messages to work properly. But at least it doesn't throw an error.
